### PR TITLE
Update unsupported target error to reflect addition of ESP32 support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ export function activate(context: vscode.ExtensionContext) {
                 break;
             }
             default: {
-                writeEmitter.fire("ERROR: Only Arduino-Pico RP2040 and ESP8266 supported.\r\n");
+                writeEmitter.fire("ERROR: Only Arduino-Pico RP2040, ESP32, and ESP8266 supported.\r\n");
                 return;
             }
         }


### PR DESCRIPTION
Support for the ESP32 family of microcontrollers was recently added to the extension (https://github.com/earlephilhower/arduino-littlefs-upload/pull/16).

When a user attempts a filesystem upload while a board of an unsupported architecture is selected in Arduino IDE, the extension displays a helpful error message which includes a list of supported targets. This message was not updated at the time the ESP32 support was added.

---

Originally reported at https://forum.arduino.cc/t/esp32-sketch-data-upload/1224606/15