### PR TITLE
Redo ESP32 partitions.csv parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arduino-littlefs-upload",
   "displayName": "arduino-littlefs-upload",
   "description": "Build and uploads LittleFS filesystems for the Arduino-Pico RP2040 core, ESP8266 core, or ESP32 core under Arduino IDE 2.2.1 or higher",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "engines": {
     "vscode": "^1.82.0"
   },


### PR DESCRIPTION
Support comments ('#'), -K and -M modifiers, don't skip 1st line,
and match on the "type" and note "name" fields.   Match "LittleFS"
type, too.

Fixes #61