### PR TITLE
Double-indirect the ESP32 partition file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arduino-littlefs-upload",
   "displayName": "arduino-littlefs-upload",
   "description": "Build and uploads LittleFS filesystems for the Arduino-Pico RP2040 core, ESP8266 core, or ESP32 core under Arduino IDE 2.2.1 or higher",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "engines": {
     "vscode": "^1.82.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ function getSelectedPartitionScheme(boardDetails : BoardDetails) : string | unde
         return;
     }
 
-    return selectedOption.value;
+    return boardDetails.buildProperties["menu.PartitionScheme." + selectedOption.value + ".build.partitions"];
 }
 
 function getDefaultPartitionScheme(boardDetails : BoardDetails) : string | undefined {


### PR DESCRIPTION
Fixes #69

The partition name menu selection's value only points to the proper line of build.properties, and is not always the file name for ESP32 partitions. Use the label to indirect to the board props to select the right file.