### PR TITLE
Changed esp32 OTA upload command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,7 +500,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
         } else if (esp32) {
             if (network) {
-                let espota = "tools" + path.sep + "espota.py";
+                let espota = "tools" + path.sep + "espota";
                 let espotaPath = findTool(arduinoContext, "runtime.platform.path");
                 if (espotaPath) {
                     espota = espotaPath + path.sep + espota;
@@ -511,7 +511,7 @@ export function activate(context: vscode.ExtensionContext) {
                     cmdApp = espota; // Have binary EXE on Mac/Windows
                 } else {
                     cmdApp = "python3"; // Not shipped, assumed installed on Linux
-                    uploadOpts.unshift(espota); // Need to call Python3
+                    uploadOpts.unshift(espota + ".py"); // Need to call Python3
                 }
             } else {
                 let flashMode = arduinoContext.boardDetails.buildProperties["build.flash_mode"];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -507,7 +507,7 @@ export function activate(context: vscode.ExtensionContext) {
                 }
                 uploadOpts = ["-r", "-i", serialPort, "-p", String(networkPort), "-f", imageFile, "-s"];
 
-                if ((platform() === 'win32') || (platform() === 'darwin')) {
+                if (platform() === 'win32') {
                     cmdApp = espota; // Have binary EXE on Mac/Windows
                 } else {
                     cmdApp = "python3"; // Not shipped, assumed installed on Linux

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -508,9 +508,9 @@ export function activate(context: vscode.ExtensionContext) {
                 uploadOpts = ["-r", "-i", serialPort, "-p", String(networkPort), "-f", imageFile, "-s"];
 
                 if (platform() === 'win32') {
-                    cmdApp = espota; // Have binary EXE on Mac/Windows
+                    cmdApp = espota; // Have binary EXE on Windows
                 } else {
-                    cmdApp = "python3"; // Not shipped, assumed installed on Linux
+                    cmdApp = "python3"; // Not shipped, assumed installed on Linux and MacOS
                     uploadOpts.unshift(espota + ".py"); // Need to call Python3
                 }
             } else {


### PR DESCRIPTION
Changed esp32 OTA upload command to use "espota" instead of "espota.py" under windows and macOS.

currently under Windows the upload uses espota.py (not "python espota.py") as upload command, which is invalid. On windows there is espota.exe for upload. The code change causes the upload command to be "espota" rather than "espota.py", so the executable is called.

Note: While I could verify that this fixes the problem under Windows, I could not test the change under Linux and macOS. While the change is simple enough that I don't think the current Linux behaviour should be affected, I'm not sure about macOS as I don't know whether it comes with an executable binary named "espota".