### PR TITLE
Fix octothorpe comments in ESP32 partitions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,7 +292,7 @@ export function activate(context: vscode.ExtensionContext) {
                 if (line.indexOf('#') >= 0) {
                     line = line.substring(0, line.indexOf('#'));
                 }
-                var partitionEntry = partitionDataArray[i].split(",");
+                var partitionEntry = line.split(",");
                 if (partitionEntry.length > 4) {
                     var offset = fancyParseInt(partitionEntry[3]);
                     var length = fancyParseInt(partitionEntry[4]);


### PR DESCRIPTION
The code took each partitions.csv line and cut off everything after a "#"....and then threq out the cut line and parsed the original. This means it would parse commented lines as if they just had a name of "#spiffs", for example.

Actually use the trimmed line in calculations.

Fixes #90